### PR TITLE
Rename `value` -> `high_value`, add `color`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ and a suit:
  - `♡` (`Heart`)
  - `♢` (`Diamond`)
 
-The value of the rank can be retrieved from `value` and `low_value`:
+The high_value of the rank can be retrieved from `high_value` and `low_value`:
 
- - `value(::Card{NumberCard{N}}) where {N} = N`
- - `value(::Card{Jack}) = 11`
- - `value(::Card{Queen}) = 12`
- - `value(::Card{King}) = 13`
- - `value(::Card{Ace}) = 14`, `low_value(::Card{Ace}) = 1`
- - `value(card::Card) = low_value(card)`
+ - `high_value(::Card{NumberCard{N}}) where {N} = N`
+ - `high_value(::Card{Jack}) = 11`
+ - `high_value(::Card{Queen}) = 12`
+ - `high_value(::Card{King}) = 13`
+ - `high_value(::Card{Ace}) = 14`, `low_value(::Card{Ace}) = 1`
+ - `high_value(card::Card) = low_value(card)`
 
 `Card`s have convenience constructors and methods for extracting information about them:
 
@@ -67,10 +67,10 @@ Heart()
 julia> rank(A♠)
 Ace()
 
-julia> value(A♢)
+julia> high_value(A♢)
 14
 
-julia> value(J♣)
+julia> high_value(J♣)
 11
 
 julia> low_value(A♡)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -13,7 +13,7 @@ Card
 suit
 rank
 rank_type
-value
+high_value
 low_value
 ```
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -15,6 +15,7 @@ rank
 rank_type
 high_value
 low_value
+color
 ```
 
 ## Auxiliary methods

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -18,14 +18,14 @@ and a suit:
  - `♡` (`Heart`)
  - `♢` (`Diamond`)
 
-The value of the rank can be retrieved from `value` and `low_value`:
+The high_value of the rank can be retrieved from `high_value` and `low_value`:
 
- - `value(::Card{NumberCard{N}}) where {N} = N`
- - `value(::Card{Jack}) = 11`
- - `value(::Card{Queen}) = 12`
- - `value(::Card{King}) = 13`
- - `value(::Card{Ace}) = 14`, `low_value(::Card{Ace}) = 1`
- - `value(card::Card) = low_value(card)`
+ - `high_value(::Card{NumberCard{N}}) where {N} = N`
+ - `high_value(::Card{Jack}) = 11`
+ - `high_value(::Card{Queen}) = 12`
+ - `high_value(::Card{King}) = 13`
+ - `high_value(::Card{Ace}) = 14`, `low_value(::Card{Ace}) = 1`
+ - `high_value(card::Card) = low_value(card)`
 
 `Card`s have convenience constructors and methods for extracting information about them:
 
@@ -35,8 +35,8 @@ using PlayingCards
 @show string(card)
 @show suit(A♡)
 @show rank(A♠)
-@show value(A♢)
-@show value(J♣)
+@show high_value(A♢)
+@show high_value(J♣)
 @show low_value(A♡)
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -38,6 +38,7 @@ using PlayingCards
 @show high_value(A♢)
 @show high_value(J♣)
 @show low_value(A♡)
+nothing
 ```
 
 ## Decks

--- a/readme_example.jl
+++ b/readme_example.jl
@@ -4,8 +4,8 @@ card = A♡
 string(card)
 suit(A♡)
 rank(A♠)
-value(A♢)
-value(J♣)
+high_value(A♢)
+high_value(J♣)
 low_value(A♡)
 
 # Deck

--- a/src/PlayingCards.jl
+++ b/src/PlayingCards.jl
@@ -260,7 +260,7 @@ end
 
 Remove `n` cards from the `deck`.
 """
-Base.pop!(deck::Deck, n::Integer) = ntuple(i->pop!(deck.cards), n)
+Base.pop!(deck::Deck, n::Integer = 1) = ntuple(i->pop!(deck.cards), n)
 
 """
     ordered_deck

--- a/src/PlayingCards.jl
+++ b/src/PlayingCards.jl
@@ -9,7 +9,7 @@ export NumberCard, Jack, Queen, King, Ace
 export Club, Spade, Heart, Diamond
 export Card, Suit, Rank
 export full_deck
-export suit, value, low_value, rank_type
+export suit, high_value, low_value, rank_type
 export ♣, ♠, ♡, ♢
 
 export ranks, suits, rank
@@ -131,30 +131,30 @@ Base.show(io::IO, card::Card) = print(io, string(card))
 # TODO: define Base.isless ? Problem: high Ace vs. low Ace
 
 """
-    value(::Card)
-    value(::Rank)
+    high_value(::Card)
+    high_value(::Rank)
 
-The rank value. For example:
- - `Ace` -> 14 (takes high value, use [`low_value`](@ref) for low value.)
+The rank high_value. For example:
+ - `Ace` -> 14 (takes high high_value, use [`low_value`](@ref) for low high_value.)
  - `Jack` -> 11
  - `NumberCard{N}` -> N
 """
-value(r::Rank) = value(typeof(r))
-value(::NumberCard{V}) where {V} = V
-value(::Type{NumberCard{N}}) where {N} = N
-value(::Type{Jack}) = 11
-value(::Type{Queen}) = 12
-value(::Type{King}) = 13
-value(::Type{Ace}) = 14
+high_value(r::Rank) = high_value(typeof(r))
+high_value(::NumberCard{V}) where {V} = V
+high_value(::Type{NumberCard{N}}) where {N} = N
+high_value(::Type{Jack}) = 11
+high_value(::Type{Queen}) = 12
+high_value(::Type{King}) = 13
+high_value(::Type{Ace}) = 14
 
 """
     low_value(::Card)
     low_value(::Rank)
 
-The low value of the rank (same as `value` except for
+The low high_value of the rank (same as `high_value` except for
 `Ace` for which `low_value(Card{Ace}) = 1`.
 """
-low_value(::Type{T}) where {T} = value(T)
+low_value(::Type{T}) where {T} = high_value(T)
 low_value(::Type{Ace}) = 1
 low_value(r::Rank) = low_value(typeof(r))
 low_value(card::Card) = low_value(rank(card))
@@ -167,7 +167,7 @@ The type of the `rank`.
 rank_type(::Card{R,S}) where {R,S} = R
 rank_type(::Type{Card{R,S}}) where {R,S} = R
 
-value(c::Card) = value(c.rank)
+high_value(c::Card) = high_value(c.rank)
 
 """
     rank(::Card)

--- a/src/PlayingCards.jl
+++ b/src/PlayingCards.jl
@@ -5,16 +5,24 @@ import Random: shuffle!
 
 import Base
 
+# Ranks
 export NumberCard, Jack, Queen, King, Ace
+
+# Suits
 export Club, Spade, Heart, Diamond
+export ♣, ♠, ♡, ♢ # aliases
+
+# Card, and Suit / Rank
 export Card, Suit, Rank
-export full_deck
-export suit, high_value, low_value, rank_type
-export ♣, ♠, ♡, ♢
 
-export ranks, suits, rank
+# Card properties
+export suit, rank, rank_type, high_value, low_value, color
 
-export Deck, shuffle!, ordered_deck
+# Lists of all ranks / suits
+export ranks, suits
+
+# Deck & deck-related methods
+export Deck, shuffle!, full_deck, ordered_deck
 
 #####
 ##### Types
@@ -32,13 +40,10 @@ card suit (all of which have aliases):
 """
 abstract type Suit end
 
-abstract type RedSuit <: Suit end
-abstract type BlackSuit <: Suit end
-
-struct Club <: BlackSuit end
-struct Spade <: BlackSuit end
-struct Heart <: RedSuit end
-struct Diamond <: RedSuit end
+struct Club <: Suit end
+struct Spade <: Suit end
+struct Heart <: Suit end
+struct Diamond <: Suit end
 
 const ♣ = Club()
 const ♠ = Spade()
@@ -182,6 +187,20 @@ rank(c::Card) = c.rank
 The card `suit` (e.g., `Heart`, `Club`).
 """
 suit(c::Card) = c.suit
+
+"""
+    color(::Card)
+    color(::Suit)
+
+A Symbol (`:red`, or `:black`) indicating
+the color of the suit or card.
+"""
+color(::Type{Club}) = :black
+color(::Type{Spade}) = :black
+color(::Type{Heart}) = :red
+color(::Type{Diamond}) = :red
+color(s::Suit) = color(typeof(s))
+color(card::Card) = color(suit(card))
 
 #####
 ##### Full deck/suit/rank methods

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,17 +11,17 @@ end
 @testset "Ranks" begin
     for v in 2:10
         @test NumberCard(v) == NumberCard{v}()
-        @test value(NumberCard{v}) == low_value(NumberCard{v}) == v
+        @test high_value(NumberCard{v}) == low_value(NumberCard{v}) == v
     end
-    @test value(Jack)  == low_value(Jack) == 11
-    @test value(Queen) == low_value(Queen) == 12
-    @test value(King)  == low_value(King) == 13
-    @test value(Ace) == 14
+    @test high_value(Jack)  == low_value(Jack) == 11
+    @test high_value(Queen) == low_value(Queen) == 12
+    @test high_value(King)  == low_value(King) == 13
+    @test high_value(Ace) == 14
     @test low_value(Ace) == 1
     @test low_value(A♠) == 1
 
     for r in ranks()
-        @test value(r) == value(typeof(r))
+        @test high_value(r) == high_value(typeof(r))
     end
 end
 
@@ -30,7 +30,7 @@ end
     @test rank_type(J♣) == Jack
     @test rank(J♣) == Jack()
     @test suit(J♣) == Club()
-    @test value(J♣) == value(Jack)
+    @test high_value(J♣) == high_value(Jack)
 end
 
 @testset "strings" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,17 @@ end
     end
 end
 
+@testset "Color" begin
+    @test color(J♣) == :black
+    @test color(A♠) == :black
+    @test color(♣) == :black
+    @test color(♠) == :black
+    @test color(J♢) == :red
+    @test color(A♡) == :red
+    @test color(♢) == :red
+    @test color(♡) == :red
+end
+
 @testset "Card" begin
     @test rank_type(typeof(J♣)) == Jack
     @test rank_type(J♣) == Jack


### PR DESCRIPTION
This PR:

 - Renames `value` -> `high_value`
 - Adds `color`, which returns `:red` or `:black`, based on the suit.
 - Small doc fix
 - Makes `n` in `pop!` optional