### PR TITLE
Swap type parameters

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.1.0"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlayingCards"
 uuid = "ecfe714a-bcc2-4d11-ad00-25525ff8f984"
 authors = ["Charles Kawczynski <kawczynski.charles@gmail.com>"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ A package for representing playing cards for card games (for a standard deck of 
 
 A playing `Card` is consists of a rank:
 
- - `NumberCard(N::Int)` where `2 ≤ N ≤ 10`
- - `Jack`
- - `Queen`
- - `King`
- - `Ace`
+ - `Rank(N::Int)` where `1 ≤ N ≤ 13` where
+ - `N = 1` represents an Ace (which can have high or low values via `high_value` and `low_value`)
+ - `N = 11` represents a Jack
+ - `N = 12` represents a Queen
+ - `N = 13` represents a King
 
 and a suit:
  - `♣` (`Club`)
@@ -41,14 +41,11 @@ and a suit:
  - `♡` (`Heart`)
  - `♢` (`Diamond`)
 
-The high_value of the rank can be retrieved from `high_value` and `low_value`:
+The value of the rank can be retrieved from `high_value` and `low_value`:
 
- - `high_value(::Card{NumberCard{N}}) where {N} = N`
- - `high_value(::Card{Jack}) = 11`
- - `high_value(::Card{Queen}) = 12`
- - `high_value(::Card{King}) = 13`
- - `high_value(::Card{Ace}) = 14`, `low_value(::Card{Ace}) = 1`
- - `high_value(card::Card) = low_value(card)`
+ - `high_value(c::Card) == low_value(c::Card) == c.rank`
+ - `high_value(::Card) = 14` for Ace
+ - `low_value(::Card) = 1` for Ace
 
 `Card`s have convenience constructors and methods for extracting information about them:
 
@@ -85,10 +82,10 @@ A `Deck` is a struct with a `Vector` of `Card`s, which has a few convenience met
 julia> using PlayingCards
 
 julia> deck = ordered_deck()
-2♣  3♣  4♣  5♣  6♣  7♣  8♣  9♣  T♣  J♣  Q♣  K♣  A♣
-2♠  3♠  4♠  5♠  6♠  7♠  8♠  9♠  T♠  J♠  Q♠  K♠  A♠
-2♡  3♡  4♡  5♡  6♡  7♡  8♡  9♡  T♡  J♡  Q♡  K♡  A♡
-2♢  3♢  4♢  5♢  6♢  7♢  8♢  9♢  T♢  J♢  Q♢  K♢  A♢
+A♣ 2♣  3♣  4♣  5♣  6♣  7♣  8♣  9♣  T♣  J♣  Q♣  K♣
+A♠ 2♠  3♠  4♠  5♠  6♠  7♠  8♠  9♠  T♠  J♠  Q♠  K♠
+A♡ 2♡  3♡  4♡  5♡  6♡  7♡  8♡  9♡  T♡  J♡  Q♡  K♡
+A♢ 2♢  3♢  4♢  5♢  6♢  7♢  8♢  9♢  T♢  J♢  Q♢  K♢
 
 
 julia> shuffle!(deck)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -8,11 +8,9 @@ CurrentModule = PlayingCards
 
 ```@docs
 Suit
-Rank
 Card
 suit
 rank
-rank_type
 high_value
 low_value
 color

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,11 +6,11 @@ A package for representing playing cards for card games (for a standard deck of 
 
 A playing `Card` is consists of a rank:
 
- - `NumberCard(N::Int)` where `2 ≤ N ≤ 10`
- - `Jack`
- - `Queen`
- - `King`
- - `Ace`
+ - `Rank(N::Int)` where `1 ≤ N ≤ 13` where
+ - `N = 1` represents an Ace (which can have high or low values via `high_value` and `low_value`)
+ - `N = 11` represents a Jack
+ - `N = 12` represents a Queen
+ - `N = 13` represents a King
 
 and a suit:
  - `♣` (`Club`)
@@ -18,14 +18,11 @@ and a suit:
  - `♡` (`Heart`)
  - `♢` (`Diamond`)
 
-The high_value of the rank can be retrieved from `high_value` and `low_value`:
+The value of the rank can be retrieved from `high_value` and `low_value`:
 
- - `high_value(::Card{NumberCard{N}}) where {N} = N`
- - `high_value(::Card{Jack}) = 11`
- - `high_value(::Card{Queen}) = 12`
- - `high_value(::Card{King}) = 13`
- - `high_value(::Card{Ace}) = 14`, `low_value(::Card{Ace}) = 1`
- - `high_value(card::Card) = low_value(card)`
+ - `high_value(c::Card) == low_value(c::Card) == c.rank`
+ - `high_value(::Card) = 14` for Ace
+ - `low_value(::Card) = 1` for Ace
 
 `Card`s have convenience constructors and methods for extracting information about them:
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Test
 using PlayingCards
+using PlayingCards: rank_string
 
 @testset "Suit" begin
     @test ♣ == Club()
@@ -9,20 +10,11 @@ using PlayingCards
 end
 
 @testset "Ranks" begin
-    for v in 2:10
-        @test NumberCard(v) == NumberCard{v}()
-        @test high_value(NumberCard{v}) == low_value(NumberCard{v}) == v
+    for v in ranks()
+        v==1 && continue
+        @test high_value(v*♣) == low_value(v*♣) == v
     end
-    @test high_value(Jack)  == low_value(Jack) == 11
-    @test high_value(Queen) == low_value(Queen) == 12
-    @test high_value(King)  == low_value(King) == 13
-    @test high_value(Ace) == 14
-    @test low_value(Ace) == 1
-    @test low_value(A♠) == 1
-
-    for r in ranks()
-        @test high_value(r) == high_value(typeof(r))
-    end
+    @test low_value(1*♣) == 1
 end
 
 @testset "Color" begin
@@ -37,11 +29,10 @@ end
 end
 
 @testset "Card" begin
-    @test rank_type(typeof(J♣)) == Jack
-    @test rank_type(J♣) == Jack
-    @test rank(J♣) == Jack()
+    @test rank(J♣) == 11
     @test suit(J♣) == Club()
-    @test high_value(J♣) == high_value(Jack)
+    @test_throws AssertionError 14*♣
+    @test_throws AssertionError 0*♣
 end
 
 @testset "strings" begin
@@ -57,7 +48,7 @@ end
     @test string(♠) == "♠"
     @test string(♡) == "♡"
     @test string(♢) == "♢"
-    @test string(NumberCard{2}()) == "2"
+    @test_throws ErrorException rank_string(UInt8(0))
 end
 
 @testset "Deck" begin
@@ -70,10 +61,10 @@ end
     @test length(deck)==50
     @test length(full_deck())==52
 
-    s="2♣ 3♣ 4♣ 5♣ 6♣ 7♣ 8♣ 9♣ T♣ J♣ Q♣ K♣ A♣
-2♠ 3♠ 4♠ 5♠ 6♠ 7♠ 8♠ 9♠ T♠ J♠ Q♠ K♠ A♠
-2♡ 3♡ 4♡ 5♡ 6♡ 7♡ 8♡ 9♡ T♡ J♡ Q♡ K♡ A♡
-2♢ 3♢ 4♢ 5♢ 6♢ 7♢ 8♢ 9♢ T♢ J♢ Q♢ K♢ A♢
+    s="A♣ 2♣ 3♣ 4♣ 5♣ 6♣ 7♣ 8♣ 9♣ T♣ J♣ Q♣ K♣
+A♠ 2♠ 3♠ 4♠ 5♠ 6♠ 7♠ 8♠ 9♠ T♠ J♠ Q♠ K♠
+A♡ 2♡ 3♡ 4♡ 5♡ 6♡ 7♡ 8♡ 9♡ T♡ J♡ Q♡ K♡
+A♢ 2♢ 3♢ 4♢ 5♢ 6♢ 7♢ 8♢ 9♢ T♢ J♢ Q♢ K♢
 "
     @test sprint(show, ordered_deck()) == s
 end


### PR DESCRIPTION
I'm not sure if this makes a difference on how specialization works, but, for `PokerHandEvaluator` it's cleaner to write

```julia
hand_rank(
    c1::Card{S},
    c2::Card{S},
    c3::Card{S},
    c4,::Card{S},
    c5::Card{S}) where {S} = hand_rank_flush(c1, c2, c3, c4, c5)
```
when the suite parameter is first.