### PR TITLE
Remove suit types and use more compact card representation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlayingCards"
 uuid = "ecfe714a-bcc2-4d11-ad00-25525ff8f984"
 authors = ["Charles Kawczynski <kawczynski.charles@gmail.com>"]
-version = "0.2.2"
+version = "0.3.0"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/README.md
+++ b/README.md
@@ -27,19 +27,13 @@ A package for representing playing cards for card games (for a standard deck of 
 
 ## Cards
 
-A playing `Card` is consists of a rank:
+A playing `Card` is consists of a suit (`♣`,`♠`,`♡`,`♢`) and a rank:
 
  - `Rank(N::Int)` where `1 ≤ N ≤ 13` where
  - `N = 1` represents an Ace (which can have high or low values via `high_value` and `low_value`)
  - `N = 11` represents a Jack
  - `N = 12` represents a Queen
  - `N = 13` represents a King
-
-and a suit:
- - `♣` (`Club`)
- - `♠` (`Spade`)
- - `♡` (`Heart`)
- - `♢` (`Diamond`)
 
 The value of the rank can be retrieved from `high_value` and `low_value`:
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,19 +4,13 @@ A package for representing playing cards for card games (for a standard deck of 
 
 ## Cards
 
-A playing `Card` is consists of a rank:
+A playing `Card` is consists of a suit (`♣`,`♠`,`♡`,`♢`) and a rank:
 
  - `Rank(N::Int)` where `1 ≤ N ≤ 13` where
  - `N = 1` represents an Ace (which can have high or low values via `high_value` and `low_value`)
  - `N = 11` represents a Jack
  - `N = 12` represents a Queen
  - `N = 13` represents a King
-
-and a suit:
- - `♣` (`Club`)
- - `♠` (`Spade`)
- - `♡` (`Heart`)
- - `♢` (`Diamond`)
 
 The value of the rank can be retrieved from `high_value` and `low_value`:
 

--- a/src/PlayingCards.jl
+++ b/src/PlayingCards.jl
@@ -6,14 +6,13 @@ import Random: shuffle!
 import Base
 
 # Suits
-export Club, Spade, Heart, Diamond
 export ♣, ♠, ♡, ♢ # aliases
 
 # Card, and Suit
 export Card, Suit
 
 # Card properties
-export suit, rank, rank_type, high_value, low_value, color
+export suit, rank, high_value, low_value, color
 
 # Lists of all ranks / suits
 export ranks, suits
@@ -28,98 +27,158 @@ export Deck, shuffle!, full_deck, ordered_deck
 """
     Suit
 
-Subtypes are used for each
-card suit (all of which have aliases):
- - `Club`    (alias `♣`)
- - `Spade`   (alias `♠`)
- - `Heart`   (alias `♡`)
- - `Diamond` (alias `♢`)
+Encode a suit as a 2-bit value (low bits of a `UInt8`):
+- 0 = ♣ (clubs)
+- 1 = ♢ (diamonds)
+- 2 = ♡ (hearts)
+- 3 = ♠ (spades)
+
+Suits have global constant bindings: `♣`, `♢`, `♡`, `♠`.
 """
-abstract type Suit end
+struct Suit
+    i::UInt8
+    Suit(s::Integer) = 0 ≤ s ≤ 3 ? new(s) :
+        throw(ArgumentError("invalid suit number: $s"))
+end
 
-struct Club <: Suit end
-struct Spade <: Suit end
-struct Heart <: Suit end
-struct Diamond <: Suit end
+#=
+```
+    char(::Suit)
 
-const ♣ = Club()
-const ♠ = Spade()
-const ♡ = Heart()
-const ♢ = Diamond()
+julia> Char.(0x2663 .- UInt8.(0:3))
+4-element Array{Char,1}:
+ '♣': Unicode U+2663 (category So: Symbol, other)
+ '♢': Unicode U+2662 (category So: Symbol, other)
+ '♡': Unicode U+2661 (category So: Symbol, other)
+ '♠': Unicode U+2660 (category So: Symbol, other)
+```
+=#
 
 """
-    Card{S <: Suit, R <: Rank}
+    char
 
-A playing card. Can be constructed with
-
-`Card(suit, rank)`, or by convenience
-constructors. For example:
- - `2♢` (equivalent to `Card(2, Diamond())`)
- - `A♡` (equivalent to `Card(1, Heart())`)
-
-A `10`-`suit` can be constructed with one of two constructors:
- - `10♣` (equivalent to `Card(10, Club())`)
-or
- - `T♠`  (equivalent to `Card(10, Spade())`)
+Return the unicode characters:
 """
-struct Card{S <: Suit}
-    rank::UInt8
-    # Support either order input:
-    function Card(rank::Int, ::S) where {S<:Suit}
-        @assert 1 ≤ rank ≤ 13
-        new{S}(UInt8(rank))
-    end
-    function Card(::S, rank::Int) where {S<:Suit}
-        @assert 1 ≤ rank ≤ 13
-        new{S}(UInt8(rank))
+char(s::Suit) = Char(0x2663-s.i)
+Base.string(s::Suit) = string(char(s))
+Base.show(io::IO, s::Suit) = print(io, char(s))
+
+"""
+    Card
+
+Encode a playing card as a 6-bit integer (low bits of a `UInt8`):
+- low bits represent rank from 0 to 15
+- high bits represent suit (♣, ♢, ♡ or ♠)
+
+Ranks are assigned as follows:
+- numbered cards (2 to 10) have rank equal to their number
+- jacks, queens and kings have ranks 11, 12 and 13
+- there are low and high aces with ranks 1 and 14
+- there are low and high jokers with ranks 0 and 15
+
+This allows any of the standard orderings of cards ranks to be
+achieved simply by choosing which aces to use.
+
+There are a total of 64 possible card values with this scheme,
+represented by `UInt8` values `0x00` through `0x3f`.
+"""
+struct Card
+    value::UInt8
+    function Card(r::Integer, s::Integer)
+        1 ≤ r ≤ 13 || throw(ArgumentError("invalid card rank: $r"))
+        left_bits = UInt8(s << 4)
+        right_bits = UInt8(r)
+        or_bits = left_bits | right_bits
+        return new(or_bits)
     end
 end
+
+Card(r::Integer, s::Suit) = Card(r, s.i)
+
+#=
+```julia
+value(r, s) = UInt8(s << 4) | UInt8(r)
+suit(r, s) = (0x30 & value(r, s)) >>> 4
+julia> suit(1, 0)+0 # 0
+julia> suit(1, 1)+0 # 1
+julia> suit(1, 2)+0 # 2
+julia> suit(1, 3)+0 # 3
+```
+=#
+
+"""
+    suit(::Card)
+
+The suit of a card
+"""
+suit(c::Card) = Suit((0x30 & c.value) >>> 4)
+
+#=
+```julia
+value(r, s) = UInt8(s << 4) | UInt8(r)
+rank(r, s) = Int8((0x0f & value(r, s)))
+julia> rank(1, 0)+0 # 1
+julia> rank(1, 3)+0 # 1
+julia> rank(9, 3)+0 # 9
+```
+=#
+
+"""
+    rank(::Card)
+
+The rank of a card
+"""
+rank(c::Card) = Int8((c.value & 0x0f))
+
+const ♣ = Suit(0)
+const ♢ = Suit(1)
+const ♡ = Suit(2)
+const ♠ = Suit(3)
 
 # Allow constructing cards with, e.g., `3♡`
-Base.:*(r::Integer, s::Suit) = Card(s, r)
+Base.:*(r::Integer, s::Suit) = Card(r, s)
+
+function Base.show(io::IO, c::Card)
+    r = rank(c)
+    @assert 1 ≤ r ≤ 14
+    if r == 1
+        print(io, 'A')
+    else
+        print(io, "123456789TJQK"[r])
+    end
+    print(io, suit(c))
+end
 
 # And for face cards:
-# Not to be confused with
+# Not to be confused with other unicode characters:
 # ♡, ♡
 # ♢, ♢
-for s in "♣♢♡♠", (f,typ) in zip((:J,:Q,:K,:A),(11,12,13,1))
+for s in "♣♢♡♠", (f,typ) in zip((:T,:J,:Q,:K,:A),(10,11,12,13,1))
     ss, sc = Symbol(s), Symbol("$f$s")
     @eval (export $sc; const $sc = Card($typ,$ss))
-end
-for s in "♣♢♡♠"
-    ss, sc = Symbol(s), Symbol("T$s")
-    @eval (export $sc; const $sc = Card(10,$ss))
 end
 
 #####
 ##### Methods
 #####
 
-Base.string(::Club) = "♣"
-Base.string(::Spade) = "♠"
-Base.string(::Heart) = "♡"
-Base.string(::Diamond) = "♢"
-Base.string(::Type{Club}) = "♣"
-Base.string(::Type{Spade}) = "♠"
-Base.string(::Type{Heart}) = "♡"
-Base.string(::Type{Diamond}) = "♢"
-
-function rank_string(r::UInt8)
-    2 ≤ r ≤ 9 && return "$(r)"
-    r == 10 && return "T"
-    r == 11 && return "J"
-    r == 12 && return "Q"
-    r == 13 && return "K"
-    r == 1 && return "A"
-    error("Unrecognized rank string")
+function rank_string(r::Int8)
+    @assert 1 ≤ r ≤ 13
+    if r ≤ 9
+        2 ≤ r && return "$(r)"
+        return "A"
+    else
+        if r < 12
+            r == 11 && return "J"
+            return "T"
+        else
+            r == 12 && return "Q"
+            return "K"
+        end
+    end
 end
 
-suit_type(card::Card{S}) where {S} = string(S)
-Base.string(card::Card) = rank_string(card.rank)*string(suit_type(card))
-
-Base.show(io::IO, card::Card) = print(io, string(card))
-
-# TODO: define Base.isless ? Problem: high Ace vs. low Ace
+Base.string(card::Card) = rank_string(rank(card))*string(suit(card))
 
 """
     high_value(::Card)
@@ -129,7 +188,7 @@ The high rank value. For example:
  - `Rank(1)` -> 14 (use [`low_value`](@ref) for the low Ace value.)
  - `Rank(5)` -> 5
 """
-high_value(c::Card) = c.rank == 1 ? 14 : c.rank
+high_value(c::Card) = rank(c) == 1 ? 14 : rank(c)
 
 """
     low_value(::Card)
@@ -139,35 +198,22 @@ The low rank value. For example:
  - `Rank(1)` -> 1 (use [`high_value`](@ref) for the high Ace value.)
  - `Rank(5)` -> 5
 """
-low_value(c::Card) = c.rank
-
-"""
-    rank(::Card)
-
-The card `rank` (e.g., `Ace`, `Rank`).
-"""
-rank(c::Card) = c.rank
-
-"""
-    suit(::Card)
-
-The card `suit` (e.g., `Heart`, `Club`).
-"""
-suit(c::Card{S}) where {S} = S()
+low_value(c::Card) = rank(c)
 
 """
     color(::Card)
-    color(::Suit)
 
 A `Symbol` (`:red`, or `:black`) indicating
 the color of the suit or card.
 """
-color(::Type{Club}) = :black
-color(::Type{Spade}) = :black
-color(::Type{Heart}) = :red
-color(::Type{Diamond}) = :red
-color(suit::Suit) = color(typeof(suit))
-color(card::Card{S}) where {S} = color(S)
+function color(s::Suit)
+    if s == ♣ || s == ♠
+        return :black
+    else
+        return :red
+    end
+end
+color(card::Card) = color(suit(card))
 
 #####
 ##### Full deck/suit/rank methods

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,13 +2,6 @@ using Test
 using PlayingCards
 using PlayingCards: rank_string
 
-@testset "Suit" begin
-    @test ♣ == Club()
-    @test ♠ == Spade()
-    @test ♡ == Heart()
-    @test ♢ == Diamond()
-end
-
 @testset "Ranks" begin
     for v in ranks()
         v==1 && continue
@@ -30,9 +23,16 @@ end
 
 @testset "Card" begin
     @test rank(J♣) == 11
-    @test suit(J♣) == Club()
-    @test_throws AssertionError 14*♣
-    @test_throws AssertionError 0*♣
+    @test suit(J♣) == ♣
+    @test suit(J♡) == ♡
+    @test suit(J♢) == ♢
+    @test suit(J♠) == ♠
+    @test suit(A♣) == ♣
+    @test suit(A♡) == ♡
+    @test suit(A♢) == ♢
+    @test suit(A♠) == ♠
+    @test_throws ArgumentError 14*♣
+    @test_throws ArgumentError 0*♣
 end
 
 @testset "strings" begin
@@ -48,7 +48,7 @@ end
     @test string(♠) == "♠"
     @test string(♡) == "♡"
     @test string(♢) == "♢"
-    @test_throws ErrorException rank_string(UInt8(0))
+    @test_throws AssertionError rank_string(Int8(-1))
 end
 
 @testset "Deck" begin
@@ -74,4 +74,9 @@ A♢ 2♢ 3♢ 4♢ 5♢ 6♢ 7♢ 8♢ 9♢ T♢ J♢ Q♢ K♢
     @test length(deck) == 51
     @test findfirst(x->x==5♠, deck.cards) == nothing
     @test_throws ErrorException pop!(deck, 5♠)
+end
+
+@testset "Allocations" begin
+    alloc = @allocated ordered_deck()
+    @test alloc == 304
 end


### PR DESCRIPTION
We've had some downstream issues with writing type-stable code using cards that have different types (due to suit types). So, this PR uses more pieces from Cards.jl, regarding the underlying representation, and removes support suit _types_.