### PR TITLE
Add RNG to Shuffle, Change Deck to AbstractVector

### DIFF
--- a/src/PlayingCards.jl
+++ b/src/PlayingCards.jl
@@ -1,6 +1,6 @@
 module PlayingCards
 
-using Random: randperm
+using Random: randperm, AbstractRNG, default_rng
 import Random: shuffle!
 
 import Base
@@ -18,7 +18,7 @@ export suit, rank, high_value, low_value, color
 export ranks, suits
 
 # Deck & deck-related methods
-export Deck, shuffle!, full_deck, ordered_deck
+export Deck, shuffle, shuffle!, full_deck, ordered_deck
 
 #####
 ##### Types
@@ -249,7 +249,7 @@ full_deck() = Card[Card(r,s) for s in suits() for r in ranks()]
 
 Deck of cards (backed by a `Vector{Card}`)
 """
-struct Deck{C <: Vector}
+struct Deck{C <: AbstractVector{<:Card}}
     cards::C
 end
 
@@ -292,14 +292,25 @@ An ordered `Deck` of cards.
 ordered_deck() = Deck(full_deck())
 
 """
+    shuffled_deck
+
+A randomly shuffled `Deck` of 52 cards
+"""
+shuffled_deck(rng::AbstractRNG = default_rng()) = shuffle!(ordered_deck())
+
+"""
     shuffle!
 
-Shuffle the deck! `shuffle!` uses
-`Random.randperm` to shuffle the deck.
+Shuffle the deck! Optionally accepts an `AbstractRNG` to seed the shuffle.
 """
-function shuffle!(deck::Deck)
-    deck.cards .= deck.cards[randperm(length(deck.cards))]
-    deck
+shuffle!(deck::Deck) = shuffle!(default_rng(), deck)
+
+function shuffle!(rng::AbstractRNG, deck::Deck)
+    shuffle!(rng, deck.cards)
+    return deck
 end
+
+shuffle(deck::Deck) = shuffle!(default_rng(), Deck(copy(deck.cards)))
+shuffle(rng::AbstractRNG, deck::Deck) = shuffle!(rng, Deck(copy(deck.cards)))
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,10 @@ using Test
 using PlayingCards
 using PlayingCards: rank_string
 
+using Random
+
+rng = VERSION >= v"1.7.0" ? Random.Xoshiro(0x0451) : Random.MersenneTwister()
+
 @testset "Ranks" begin
     for v in ranks()
         v==1 && continue
@@ -55,7 +59,7 @@ end
     deck = ordered_deck()
     @test length(deck) == 52
     @test iterate(deck) == iterate(deck.cards)
-    shuffle!(deck)
+    shuffle!(rng, deck)
     cards = pop!(deck, 2)
     @test length(cards)==2
     @test length(deck)==50


### PR DESCRIPTION
This PR makes two main changes:

`shuffle!` (and now `shuffle` as well) can be passed an `AbstractRNG` to let the user define their own RNG. If no RNG is provided, the default RNG is used instead. I also rewrote `shuffle!` to use the in-place `shuffle!(::Vector)` method so that shuffling the deck is non-allocating. 

Along with that, I wrote an out-of-place `shuffle` method which allows you to retain your original deck. 

I also changed the type parameterization for `Deck{<:Vector}` to `Deck{<:AbstractVector{Card}`. This forces the contents of `Deck` to be a vector of `Card`s, where before the `Deck` could contain any `Vector`. Using an `AbstractVector` also lets users use an alternative vector type, like an `SVector` to stack-allocate the `Deck`. 

I'm happy to throw out the `Deck{<:Vector}` change; I only included it because I didn't feel like a second PR was necessary. The `shuffle` RNG changes are my primary interest. 

I also wanted to say thanks for putting this package together. It's a very space-efficient implementation of a standard 52-card deck, and I'm looking forward to playing around with it :)