### PR TITLE
Add MaskedDeck

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlayingCards"
 uuid = "ecfe714a-bcc2-4d11-ad00-25525ff8f984"
 authors = ["Charles Kawczynski <kawczynski.charles@gmail.com>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/PlayingCards.jl
+++ b/src/PlayingCards.jl
@@ -1,6 +1,7 @@
 module PlayingCards
 
 using Random: randperm
+import Random
 import Random: shuffle!
 
 import Base
@@ -244,20 +245,13 @@ full_deck() = Card[Card(r,s) for s in suits() for r in ranks()]
 
 #### Deck
 
-"""
-    Deck
+abstract type AbstractDeck end
 
-Deck of cards (backed by a `Vector{Card}`)
-"""
-struct Deck{C <: Vector}
-    cards::C
-end
+Base.length(deck::AbstractDeck) = length(deck.cards)
 
-Base.length(deck::Deck) = length(deck.cards)
+Base.iterate(deck::AbstractDeck, state=1) = Base.iterate(deck.cards, state)
 
-Base.iterate(deck::Deck, state=1) = Base.iterate(deck.cards, state)
-
-function Base.show(io::IO, deck::Deck)
+function Base.show(io::IO, deck::AbstractDeck)
     for (i, card) in enumerate(deck)
         Base.show(io, card)
         if mod(i, 13) == 0
@@ -269,6 +263,15 @@ function Base.show(io::IO, deck::Deck)
 end
 
 """
+    Deck
+
+Deck of cards (backed by a `Vector{Card}`)
+"""
+struct Deck{C <: Vector} <: AbstractDeck
+    cards::C
+end
+
+"""
     pop!(deck::Deck, n::Int = 1)
     pop!(deck::Deck, card::Card)
 
@@ -276,7 +279,9 @@ Remove `n` cards from the `deck`.
 or
 Remove `card` from the `deck`.
 """
-Base.pop!(deck::Deck, n::Integer = 1) = ntuple(i->pop!(deck.cards), n)
+Base.pop!(deck::Deck, n::Integer = 1) = ntuple(i->Base.pop!(deck.cards), n)
+
+# TODO: `pop!` should not return a tuple
 function Base.pop!(deck::Deck, card::Card)
     L0 = length(deck)
     filter!(x -> x ≠ card, deck.cards)
@@ -301,5 +306,7 @@ function shuffle!(deck::Deck)
     deck.cards .= deck.cards[randperm(length(deck.cards))]
     deck
 end
+
+include("masked_deck.jl")
 
 end # module

--- a/src/masked_deck.jl
+++ b/src/masked_deck.jl
@@ -1,0 +1,51 @@
+"""
+    MaskedDeck()
+
+A deck of cards (backed by a `Vector{Card}`)
+that masks cards that have been removed via
+`pop!`. Two variants of `pop!` are supported:
+
+ - `pop!(::MaskedDeck)::Card`
+ - `pop!(::MaskedDeck, ::Val{n})::NTuple{n,Card}`
+
+Both methods are non-allocating and type-stable.
+`pop!(::MaskedDeck, ::Card)` is not supported
+however.
+
+MaskedDeck also supports `reset!` which
+makes all of the cards available again.
+"""
+struct MaskedDeck{T <: Vector} <: AbstractDeck
+    cards::T
+    len::Vector{Int}
+end
+Base.length(deck::MaskedDeck) = deck.len[1]
+function MaskedDeck()
+    cards = PlayingCards.full_deck()
+    return MaskedDeck{typeof(cards)}(cards, Int[length(cards)])
+end
+
+Base.pop!(deck::MaskedDeck, n::Integer) = Base.pop!(deck, Val(n))
+
+function Base.pop!(deck::MaskedDeck, ::Val{n})::NTuple{n,Card} where {n}
+    return ntuple(i->Base.pop!(deck), Val(n))
+end
+
+function Base.pop!(deck::MaskedDeck)::Card
+    @inbounds deck.len[1] -= 1
+    return @inbounds deck.cards[deck.len[1]+1]
+end
+
+function reset!(deck::MaskedDeck)
+    @inbounds deck.len[1] = length(deck.cards)
+    return nothing
+end
+
+Random.shuffle!(deck::MaskedDeck) =
+    Random.shuffle!(Random.default_rng(), deck)
+
+function Random.shuffle!(rng, deck::MaskedDeck)
+    reset!(deck)
+    Random.shuffle!(rng, deck.cards)
+    deck
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Test
 using PlayingCards
 using PlayingCards: rank_string
+using PlayingCards: MaskedDeck
 
 @testset "Ranks" begin
     for v in ranks()
@@ -83,4 +84,39 @@ end
     else
         @test alloc == 304
     end
+end
+
+@testset "MaskedDeck" begin
+    deck = MaskedDeck()
+    @test length(deck) == 52
+    @test iterate(deck) == iterate(deck.cards)
+    shuffle!(deck)
+    cards = pop!(deck, Val(2))
+    @test length(cards)==2
+    @test length(deck)==50
+    @test length(full_deck())==52
+
+    # Test pop! correctness against regular deck
+    mdeck = MaskedDeck()
+    rdeck = ordered_deck()
+    @test pop!(mdeck) == pop!(rdeck)[1]
+    @test length(mdeck) == length(rdeck)
+    @test pop!(mdeck) == pop!(rdeck)[1]
+    @test length(mdeck) == length(rdeck)
+    @test pop!(mdeck) == pop!(rdeck)[1]
+    @test length(mdeck) == length(rdeck)
+
+    @test pop!(mdeck, Val(3)) == pop!(rdeck, 3)
+    @test length(mdeck) == length(rdeck)
+    @test pop!(mdeck, Val(3)) == pop!(rdeck, 3)
+    @test length(mdeck) == length(rdeck)
+
+    # Allocations
+    pop!(mdeck, Val(2))
+    p_allocated = @allocated pop!(mdeck, Val(2))
+    @test p_allocated == 0
+
+    shuffle!(mdeck)
+    p_allocated = @allocated shuffle!(mdeck)
+    @test p_allocated == 0
 end


### PR DESCRIPTION
This PR:
 - Defines `AbstractDeck` and makes `Deck` a subtype of it
 - Defines `MaskedDeck <: AbstractDeck`, which has several type-stable and non-allocating functionalities. For example, `pop!` does not actually remove elements, but rather tracks how many cards have been popped out of the deck.
